### PR TITLE
feature: 북클럽 API 추가 (북클럽 추가, 북클럽 목록 조회, 북클럽 참가, 북클럽 나가기, 북클럽 찜하기, 북클럽 찜 해제)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,22 +24,8 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
-
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	testCompileOnly 'org.projectlombok:lombok'
-	testAnnotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.projectlombok:lombok'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+//	implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/build.gradle
+++ b/build.gradle
@@ -1,26 +1,26 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.3.5'
-	id 'io.spring.dependency-management' version '1.1.6'
+    id 'java'
+    id 'org.springframework.boot' version '3.3.5'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'com.codeit.sprint.team3'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
@@ -39,8 +39,31 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    //QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    //test
+    runtimeOnly 'com.h2database:h2'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/exception/BookClubException.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/exception/BookClubException.java
@@ -1,0 +1,22 @@
+package com.codeit.sprint.team3.backend.bookclub.adapter.exception;
+
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public abstract class BookClubException extends RuntimeException {
+    public final Map<String, String> validation = new HashMap<>();
+
+    public BookClubException(String message) {
+        super(message);
+    }
+
+    public abstract int getStatusCode();
+
+    public void addValidation(String fieldName, String message) {
+        validation.put(fieldName, message);
+    }
+}
+

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/exception/BookClubMemberAlreadyExistsException.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/exception/BookClubMemberAlreadyExistsException.java
@@ -1,0 +1,14 @@
+package com.codeit.sprint.team3.backend.bookclub.adapter.exception;
+
+public class BookClubMemberAlreadyExistsException extends BookClubException {
+    private static final String MESSAGE = "이미 참가중인 북클럽입니다.";
+
+    public BookClubMemberAlreadyExistsException() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return 400;
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/exception/BookClubNotExistException.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/exception/BookClubNotExistException.java
@@ -1,0 +1,14 @@
+package com.codeit.sprint.team3.backend.bookclub.adapter.exception;
+
+public class BookClubNotExistException extends BookClubException {
+    private static final String MESSAGE = "존재하지 않는 북클럽입니다.";
+
+    public BookClubNotExistException() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return 400;
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/exception/ExceptionController.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/exception/ExceptionController.java
@@ -1,0 +1,46 @@
+package com.codeit.sprint.team3.backend.bookclub.adapter.exception;
+
+import com.codeit.sprint.team3.backend.bookclub.adapter.in.web.response.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+
+@RestControllerAdvice
+public class ExceptionController {
+    @ResponseBody
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ErrorResponse invalidRequestHandler(MethodArgumentNotValidException e) {
+        ErrorResponse response = ErrorResponse.builder()
+                .code("400")
+                .message("잘못된 요청입니다.")
+                .validation(new HashMap<>())
+                .build();
+
+        for (FieldError fieldError : e.getFieldErrors()) {
+            response.addValidation(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+        return response;
+    }
+
+    @ResponseBody
+    @ExceptionHandler(BookClubException.class)
+    public ResponseEntity<ErrorResponse> bookClubException(BookClubException e) {
+        int statusCode = e.getStatusCode();
+        ErrorResponse body = ErrorResponse.builder()
+                .code(String.valueOf(statusCode))
+                .message(e.getMessage())
+                .validation(e.getValidation())
+                .build();
+
+        return ResponseEntity.status(statusCode)
+                .body(body);
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/exception/InvalidRequest.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/exception/InvalidRequest.java
@@ -9,10 +9,6 @@ public class InvalidRequest extends BookClubException {
     public String fieldName;
     public String message;
 
-    public InvalidRequest() {
-        super(MESSAGE);
-    }
-
     public InvalidRequest(String fieldName, String message) {
         super(MESSAGE);
         addValidation(fieldName, message);

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/exception/InvalidRequest.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/exception/InvalidRequest.java
@@ -1,0 +1,24 @@
+package com.codeit.sprint.team3.backend.bookclub.adapter.exception;
+
+import lombok.Getter;
+
+@Getter
+public class InvalidRequest extends BookClubException {
+    private static final String MESSAGE = "잘못된 요청입니다.";
+
+    public String fieldName;
+    public String message;
+
+    public InvalidRequest() {
+        super(MESSAGE);
+    }
+
+    public InvalidRequest(String fieldName, String message) {
+        super(MESSAGE);
+        addValidation(fieldName, message);
+    }
+
+    public int getStatusCode() {
+        return 400;
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/BookClubController.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/BookClubController.java
@@ -6,7 +6,7 @@ import com.codeit.sprint.team3.backend.bookclub.adapter.in.web.response.BookClub
 import com.codeit.sprint.team3.backend.bookclub.application.port.in.BookClubUseCase;
 import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
 import com.codeit.sprint.team3.backend.bookclub.domain.MeetingType;
-import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClub;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/BookClubController.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/BookClubController.java
@@ -22,7 +22,7 @@ public class BookClubController {
     @SneakyThrows
     @RequestMapping
     public ResponseEntity<Void> createBookClub(
-            @RequestPart MultipartFile image,
+            @RequestPart(required = false) MultipartFile image,
             @RequestPart(name = "data") @Valid CreateBookClubRequest createBookClubRequest
     ) {
         validateImage(image);
@@ -34,7 +34,7 @@ public class BookClubController {
 
     private void validateImage(MultipartFile image) {
         if (image.isEmpty()) {
-            throw new InvalidRequest("image", "이미지는 필수입니다.");
+            return;
         }
         //TODO 이미지 형식 제한
         long size = image.getSize();

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/BookClubController.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/BookClubController.java
@@ -2,16 +2,21 @@ package com.codeit.sprint.team3.backend.bookclub.adapter.in.web;
 
 import com.codeit.sprint.team3.backend.bookclub.adapter.exception.InvalidRequest;
 import com.codeit.sprint.team3.backend.bookclub.adapter.in.web.request.CreateBookClubRequest;
+import com.codeit.sprint.team3.backend.bookclub.adapter.in.web.response.BookClubResponses;
 import com.codeit.sprint.team3.backend.bookclub.application.port.in.BookClubUseCase;
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
+import com.codeit.sprint.team3.backend.bookclub.domain.MeetingType;
+import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/book-club")
@@ -20,7 +25,7 @@ public class BookClubController {
     private final BookClubUseCase bookClubUseCase;
 
     @SneakyThrows
-    @RequestMapping
+    @PostMapping
     public ResponseEntity<Void> createBookClub(
             @RequestPart(required = false) MultipartFile image,
             @RequestPart(name = "data") @Valid CreateBookClubRequest createBookClubRequest
@@ -41,5 +46,18 @@ public class BookClubController {
         if (size > 1024 * 1024 * 10) {
             throw new InvalidRequest("image", "이미지 크기는 10MB 이하여야 합니다.");
         }
+    }
+
+    @GetMapping
+    public ResponseEntity<BookClubResponses> findBookClubs(
+            @RequestParam(defaultValue = "ALL") String bookClubType,
+            @RequestParam(defaultValue = "ALL") String meetingType,
+            Integer memberLimit,
+            String location,
+            LocalDate targetDate
+    ) {
+        List<BookClub> bookClubs = bookClubUseCase.findBookClubsBy(BookClubType.getQueryType(bookClubType), MeetingType.getQueryType(meetingType), memberLimit, location, targetDate);
+        return ResponseEntity.ok()
+                .body(BookClubResponses.from(bookClubs));
     }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/BookClubController.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/BookClubController.java
@@ -1,8 +1,45 @@
 package com.codeit.sprint.team3.backend.bookclub.adapter.in.web;
 
+import com.codeit.sprint.team3.backend.bookclub.adapter.exception.InvalidRequest;
+import com.codeit.sprint.team3.backend.bookclub.adapter.in.web.request.CreateBookClubRequest;
+import com.codeit.sprint.team3.backend.bookclub.application.port.in.BookClubUseCase;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
+@RestController
+@RequestMapping("/api/v1/book-club")
+@RequiredArgsConstructor
 public class BookClubController {
+    private final BookClubUseCase bookClubUseCase;
 
+    @SneakyThrows
+    @RequestMapping
+    public ResponseEntity<Void> createBookClub(
+            @RequestPart MultipartFile image,
+            @RequestPart(name = "data") @Valid CreateBookClubRequest createBookClubRequest
+    ) {
+        validateImage(image);
+        //TODO 이미지 저장
+        bookClubUseCase.createBookClub(createBookClubRequest.toDomain());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .build();
+    }
 
-
+    private void validateImage(MultipartFile image) {
+        if (image.isEmpty()) {
+            throw new InvalidRequest("image", "이미지는 필수입니다.");
+        }
+        //TODO 이미지 형식 제한
+        long size = image.getSize();
+        if (size > 1024 * 1024 * 10) {
+            throw new InvalidRequest("image", "이미지 크기는 10MB 이하여야 합니다.");
+        }
+    }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/BookClubController.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/BookClubController.java
@@ -4,14 +4,15 @@ import com.codeit.sprint.team3.backend.bookclub.adapter.exception.InvalidRequest
 import com.codeit.sprint.team3.backend.bookclub.adapter.in.web.request.CreateBookClubRequest;
 import com.codeit.sprint.team3.backend.bookclub.adapter.in.web.response.BookClubResponses;
 import com.codeit.sprint.team3.backend.bookclub.application.port.in.BookClubUseCase;
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClub;
 import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
 import com.codeit.sprint.team3.backend.bookclub.domain.MeetingType;
-import com.codeit.sprint.team3.backend.bookclub.domain.BookClub;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -43,7 +44,10 @@ public class BookClubController {
         if (image.isEmpty()) {
             return;
         }
-        //TODO 이미지 형식 제한
+        //TODO 이미지 형식 제한 추가하기~
+        if (!"jpg".equals(StringUtils.getFilenameExtension(image.getOriginalFilename()))) {
+            throw new InvalidRequest("image", "이미지는 jpg 형식이어야 합니다.");
+        }
         long size = image.getSize();
         if (size > 1024 * 1024 * 10) {
             throw new InvalidRequest("image", "이미지 크기는 10MB 이하여야 합니다.");

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/BookClubController.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/BookClubController.java
@@ -55,7 +55,7 @@ public class BookClubController {
             @RequestParam(defaultValue = "ALL") String bookClubType,
             @RequestParam(defaultValue = "ALL") String meetingType,
             Integer memberLimit,
-            String location,
+            String location, //동 단위 town
             LocalDate targetDate
     ) {
         List<BookClub> bookClubs = bookClubUseCase.findBookClubsBy(BookClubType.getQueryType(bookClubType), MeetingType.getQueryType(meetingType), memberLimit, location, targetDate);

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/BookClubController.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/BookClubController.java
@@ -19,7 +19,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/book-club")
+@RequestMapping("/api/v1/book-clubs")
 @RequiredArgsConstructor
 public class BookClubController {
     private final BookClubUseCase bookClubUseCase;
@@ -32,7 +32,9 @@ public class BookClubController {
     ) {
         validateImage(image);
         //TODO 이미지 저장
-        bookClubUseCase.createBookClub(createBookClubRequest.toDomain());
+        //TODO 유저 security context에서 아이디 가져오기
+        Long userId = 1L;
+        bookClubUseCase.createBookClub(createBookClubRequest.toDomain(), userId);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .build();
     }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/BookClubLikeController.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/BookClubLikeController.java
@@ -1,0 +1,32 @@
+package com.codeit.sprint.team3.backend.bookclub.adapter.in.web;
+
+import com.codeit.sprint.team3.backend.bookclub.application.port.in.BookClubLikeUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/book-clubs/likes")
+public class BookClubLikeController {
+    private final BookClubLikeUseCase bookClubLikeUseCase;
+
+    @PostMapping("/{id}")
+    public ResponseEntity<Void> likeBookClub(@PathVariable Long id) {
+        //TODO 로그인 여부 확인 및 데이터 가져오기
+        Long userId = 1L;
+        bookClubLikeUseCase.saveBookClubLike(id, userId);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> unlikeBookClub(@PathVariable Long id) {
+        //TODO 로그인 여부 확인 및 데이터 가져오기
+        Long userId = 1L;
+        bookClubLikeUseCase.deleteBookClubLike(id, userId);
+        return ResponseEntity.noContent()
+                .build();
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/BookClubMemberController.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/BookClubMemberController.java
@@ -1,0 +1,31 @@
+package com.codeit.sprint.team3.backend.bookclub.adapter.in.web;
+
+import com.codeit.sprint.team3.backend.bookclub.application.port.in.BookClubMemberUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/book-clubs")
+public class BookClubMemberController {
+    private final BookClubMemberUseCase bookClubMemberUseCase;
+
+    @PostMapping("/join/{id}")
+    public ResponseEntity<Void> joinBookClub(@PathVariable Long id) {
+        //TODO 로그인 여부 확인 및 데이터 가져오기
+        Long userId = 1L;
+        bookClubMemberUseCase.joinBookClub(id, userId);
+        return ResponseEntity.ok()
+                .build();
+    }
+
+    @DeleteMapping("/leave/{id}")
+    public ResponseEntity<Void> leaveBookClub(@PathVariable Long id) {
+        //TODO 로그인 여부 확인 및 데이터 가져오기
+        Long userId = 1L;
+        bookClubMemberUseCase.leaveBookClub(id, userId);
+        return ResponseEntity.noContent()
+                .build();
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/request/CreateBookClubRequest.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/request/CreateBookClubRequest.java
@@ -1,26 +1,32 @@
 package com.codeit.sprint.team3.backend.bookclub.adapter.in.web.request;
 
 import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
+import com.codeit.sprint.team3.backend.bookclub.domain.MeetingType;
 import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
 
 public record CreateBookClubRequest(
         @NotBlank(message = "타이틀은 필수입니다.")
         String title,
+        @NotBlank(message = "상세설명은 필수입니다.")
+        String description,
         @NotBlank(message = "북클럽 타입은 필수입니다.")
         String bookClubType,
-        @NotBlank(message = "모임 날짜는 필수입니다.")
+        @NotBlank(message = "온/오프라인 여부는 필수입니다.")
+        String meetingType,
+        @NotNull(message = "모임 날짜는 필수입니다.")
         LocalDate targetDate,
-        @NotBlank(message = "마감 날짜는 필수입니다.")
+        @NotNull(message = "마감 날짜는 필수입니다.")
         LocalDate endDate,
-        @NotBlank(message = "모집 정원은 필수입니다.")
-        int memberLimit,
+        @NotNull(message = "모집 정원은 필수입니다.")
+        Integer memberLimit,
         String city,
         String town
 ) {
     public BookClub toDomain() {
-        return BookClub.of(title, BookClubType.from(bookClubType), targetDate, endDate, memberLimit, city, town);
+        return BookClub.of(title, description, MeetingType.getCommandType(meetingType), BookClubType.getCommandType(bookClubType), targetDate, endDate, memberLimit, city, town);
     }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/request/CreateBookClubRequest.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/request/CreateBookClubRequest.java
@@ -16,9 +16,11 @@ public record CreateBookClubRequest(
         @NotBlank(message = "마감 날짜는 필수입니다.")
         LocalDate endDate,
         @NotBlank(message = "모집 정원은 필수입니다.")
-        int memberLimit
+        int memberLimit,
+        String city,
+        String town
 ) {
     public BookClub toDomain() {
-        return BookClub.of(title, BookClubType.from(bookClubType), targetDate, endDate, memberLimit);
+        return BookClub.of(title, BookClubType.from(bookClubType), targetDate, endDate, memberLimit, city, town);
     }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/request/CreateBookClubRequest.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/request/CreateBookClubRequest.java
@@ -2,7 +2,7 @@ package com.codeit.sprint.team3.backend.bookclub.adapter.in.web.request;
 
 import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
 import com.codeit.sprint.team3.backend.bookclub.domain.MeetingType;
-import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClub;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/request/CreateBookClubRequest.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/request/CreateBookClubRequest.java
@@ -1,0 +1,24 @@
+package com.codeit.sprint.team3.backend.bookclub.adapter.in.web.request;
+
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
+import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.LocalDate;
+
+public record CreateBookClubRequest(
+        @NotBlank(message = "타이틀은 필수입니다.")
+        String title,
+        @NotBlank(message = "북클럽 타입은 필수입니다.")
+        String bookClubType,
+        @NotBlank(message = "모임 날짜는 필수입니다.")
+        LocalDate targetDate,
+        @NotBlank(message = "마감 날짜는 필수입니다.")
+        LocalDate endDate,
+        @NotBlank(message = "모집 정원은 필수입니다.")
+        int memberLimit
+) {
+    public BookClub toDomain() {
+        return BookClub.of(title, BookClubType.from(bookClubType), targetDate, endDate, memberLimit);
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/response/BookClubResponse.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/response/BookClubResponse.java
@@ -14,7 +14,8 @@ public record BookClubResponse(
         String endDate,
         int memberLimit,
         String city,
-        String town
+        String town,
+        int memberCount
 ) {
     public static BookClubResponse from(BookClub bookClub) {
         return new BookClubResponse(
@@ -27,7 +28,8 @@ public record BookClubResponse(
                 bookClub.getEndDate().toString(),
                 bookClub.getMemberLimit(),
                 bookClub.getCity(),
-                bookClub.getTown()
+                bookClub.getTown(),
+                bookClub.getMemberCount()
         );
     }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/response/BookClubResponse.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/response/BookClubResponse.java
@@ -1,0 +1,33 @@
+package com.codeit.sprint.team3.backend.bookclub.adapter.in.web.response;
+
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
+import com.codeit.sprint.team3.backend.bookclub.domain.MeetingType;
+import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
+
+public record BookClubResponse(
+        Long id,
+        String title,
+        String description,
+        MeetingType meetingType,
+        BookClubType bookClubType,
+        String targetDate,
+        String endDate,
+        int memberLimit,
+        String city,
+        String town
+) {
+    public static BookClubResponse from(BookClub bookClub) {
+        return new BookClubResponse(
+                bookClub.getId(),
+                bookClub.getTitle(),
+                bookClub.getDescription(),
+                bookClub.getMeetingType(),
+                bookClub.getBookClubType(),
+                bookClub.getTargetDate().toString(),
+                bookClub.getEndDate().toString(),
+                bookClub.getMemberLimit(),
+                bookClub.getCity(),
+                bookClub.getTown()
+        );
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/response/BookClubResponse.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/response/BookClubResponse.java
@@ -2,7 +2,7 @@ package com.codeit.sprint.team3.backend.bookclub.adapter.in.web.response;
 
 import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
 import com.codeit.sprint.team3.backend.bookclub.domain.MeetingType;
-import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClub;
 
 public record BookClubResponse(
         Long id,

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/response/BookClubResponses.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/response/BookClubResponses.java
@@ -1,0 +1,14 @@
+package com.codeit.sprint.team3.backend.bookclub.adapter.in.web.response;
+
+import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
+
+import java.util.List;
+
+public record BookClubResponses(List<BookClubResponse> bookClubs) {
+    public static BookClubResponses from(List<BookClub> bookClubs) {
+        List<BookClubResponse> list = bookClubs.stream()
+                .map(BookClubResponse::from)
+                .toList();
+        return new BookClubResponses(list);
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/response/BookClubResponses.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/response/BookClubResponses.java
@@ -1,6 +1,6 @@
 package com.codeit.sprint.team3.backend.bookclub.adapter.in.web.response;
 
-import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClub;
 
 import java.util.List;
 

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/response/ErrorResponse.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/in/web/response/ErrorResponse.java
@@ -1,0 +1,25 @@
+package com.codeit.sprint.team3.backend.bookclub.adapter.in.web.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class ErrorResponse {
+    private final String code;
+    private final String message;
+    private final Map<String, String> validation;
+
+    @Builder(access = AccessLevel.PUBLIC)
+    public ErrorResponse(String code, String message, Map<String, String> validation) {
+        this.code = code;
+        this.message = message;
+        this.validation = validation;
+    }
+
+    public void addValidation(String fieldName, String errorMessage) {
+        this.validation.put(fieldName, errorMessage);
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/JpaBookClubAdapter.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/JpaBookClubAdapter.java
@@ -1,6 +1,7 @@
 package com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence;
 
 import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity.BookClubEntity;
+import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.repository.BookClubDto;
 import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.repository.BookClubEntityRepository;
 import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.repository.BookClubQueryRepository;
 import com.codeit.sprint.team3.backend.bookclub.application.port.out.CommandBookClubPort;
@@ -32,7 +33,7 @@ public class JpaBookClubAdapter implements CommandBookClubPort, QueryBookClubPor
         //TODO: 찜 구현 후 찜 추가하기
         return bookClubQueryRepository.findBookClubsBy(bookClubType, meetingType, memberLimit, location, targetDate)
                 .stream()
-                .map(BookClubEntity::toModel)
+                .map(BookClubDto::toModel)
                 .toList();
     }
 

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/JpaBookClubAdapter.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/JpaBookClubAdapter.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -21,8 +22,8 @@ public class JpaBookClubAdapter implements CommandBookClubPort, QueryBookClubPor
     private final BookClubQueryRepository bookClubQueryRepository;
 
     @Override
-    public BookClub saveBookClub(BookClub bookClub) {
-        return bookClubEntityRepository.save(BookClubEntity.from(bookClub))
+    public BookClub saveBookClub(BookClub bookClub, Long userId) {
+        return bookClubEntityRepository.save(BookClubEntity.of(bookClub, userId))
                 .toModel();
     }
 
@@ -33,5 +34,11 @@ public class JpaBookClubAdapter implements CommandBookClubPort, QueryBookClubPor
                 .stream()
                 .map(BookClubEntity::toModel)
                 .toList();
+    }
+
+    @Override
+    public Optional<BookClub> getById(Long bookClubId) {
+        return bookClubEntityRepository.findById(bookClubId)
+                .map(BookClubEntity::toModel);
     }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/JpaBookClubAdapter.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/JpaBookClubAdapter.java
@@ -7,7 +7,7 @@ import com.codeit.sprint.team3.backend.bookclub.application.port.out.CommandBook
 import com.codeit.sprint.team3.backend.bookclub.application.port.out.QueryBookClubPort;
 import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
 import com.codeit.sprint.team3.backend.bookclub.domain.MeetingType;
-import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClub;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/JpaBookClubAdapter.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/JpaBookClubAdapter.java
@@ -2,20 +2,36 @@ package com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence;
 
 import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity.BookClubEntity;
 import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.repository.BookClubEntityRepository;
+import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.repository.BookClubQueryRepository;
 import com.codeit.sprint.team3.backend.bookclub.application.port.out.CommandBookClubPort;
 import com.codeit.sprint.team3.backend.bookclub.application.port.out.QueryBookClubPort;
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
+import com.codeit.sprint.team3.backend.bookclub.domain.MeetingType;
 import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
 public class JpaBookClubAdapter implements CommandBookClubPort, QueryBookClubPort {
     private final BookClubEntityRepository bookClubEntityRepository;
+    private final BookClubQueryRepository bookClubQueryRepository;
 
     @Override
     public BookClub saveBookClub(BookClub bookClub) {
         return bookClubEntityRepository.save(BookClubEntity.from(bookClub))
                 .toModel();
+    }
+
+    @Override
+    public List<BookClub> findBookClubsBy(BookClubType bookClubType, MeetingType meetingType, Integer memberLimit, String location, LocalDate targetDate) {
+        //TODO: 찜 구현 후 찜 추가하기
+        return bookClubQueryRepository.findBookClubsBy(bookClubType, meetingType, memberLimit, location, targetDate)
+                .stream()
+                .map(BookClubEntity::toModel)
+                .toList();
     }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/JpaBookClubAdapter.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/JpaBookClubAdapter.java
@@ -1,6 +1,21 @@
 package com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence;
 
-import com.codeit.sprint.team3.backend.bookclub.application.port.out.SaveBookClubPort;
+import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity.BookClubEntity;
+import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.repository.BookClubEntityRepository;
+import com.codeit.sprint.team3.backend.bookclub.application.port.out.CommandBookClubPort;
+import com.codeit.sprint.team3.backend.bookclub.application.port.out.QueryBookClubPort;
+import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
-public class JpaBookClubAdapter implements SaveBookClubPort {
+@Repository
+@RequiredArgsConstructor
+public class JpaBookClubAdapter implements CommandBookClubPort, QueryBookClubPort {
+    private final BookClubEntityRepository bookClubEntityRepository;
+
+    @Override
+    public BookClub saveBookClub(BookClub bookClub) {
+        return bookClubEntityRepository.save(BookClubEntity.from(bookClub))
+                .toModel();
+    }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/JpaBookClubLikeAdapter.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/JpaBookClubLikeAdapter.java
@@ -1,0 +1,31 @@
+package com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence;
+
+import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity.BookClubLikeEntity;
+import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.repository.BookClubLikeEntityRepository;
+import com.codeit.sprint.team3.backend.bookclub.application.port.out.BookClubLikePort;
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClubLike;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class JpaBookClubLikeAdapter implements BookClubLikePort {
+    private final BookClubLikeEntityRepository bookClubLikeEntityRepository;
+
+    @Override
+    public void saveBookClubLike(BookClubLike bookClubLike) {
+        Optional<BookClubLikeEntity> bookClubLikeEntity = bookClubLikeEntityRepository.findByBookClubIdAndUserId(bookClubLike.getBookClubId(), bookClubLike.getUserId());
+        if (bookClubLikeEntity.isPresent()) {
+            return;
+        }
+        bookClubLikeEntityRepository.save(BookClubLikeEntity.from(bookClubLike));
+    }
+
+    @Override
+    public void deleteBookClubLike(BookClubLike bookClubLike) {
+        bookClubLikeEntityRepository.findByBookClubIdAndUserId(bookClubLike.getBookClubId(), bookClubLike.getUserId())
+                .ifPresent(bookClubLikeEntityRepository::delete);
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/JpaBookClubMemberAdapter.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/JpaBookClubMemberAdapter.java
@@ -1,0 +1,18 @@
+package com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence;
+
+import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity.BookClubMemberEntity;
+import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.repository.BookClubMemberEntityRepository;
+import com.codeit.sprint.team3.backend.bookclub.application.port.out.CommandBookClubMemberPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class JpaBookClubMemberAdapter implements CommandBookClubMemberPort {
+    private final BookClubMemberEntityRepository bookClubMemberEntityRepository;
+
+    @Override
+    public void save(BookClubMemberEntity bookClubMemberEntity) {
+        bookClubMemberEntityRepository.save(bookClubMemberEntity);
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/JpaBookClubMemberAdapter.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/JpaBookClubMemberAdapter.java
@@ -15,4 +15,20 @@ public class JpaBookClubMemberAdapter implements CommandBookClubMemberPort {
     public void save(BookClubMemberEntity bookClubMemberEntity) {
         bookClubMemberEntityRepository.save(bookClubMemberEntity);
     }
+
+    @Override
+    public boolean existsByBookClubIdAndUserId(Long bookClubId, Long userId) {
+        return bookClubMemberEntityRepository.existsByBookClubIdAndUserIdAndIsInactiveFalse(bookClubId, userId);
+    }
+
+    @Override
+    public void joinBookClub(Long bookClubId, Long userId) {
+        bookClubMemberEntityRepository.save(BookClubMemberEntity.of(bookClubId, userId));
+    }
+
+    @Override
+    public void leaveBookClub(Long bookClubId, Long userId) {
+        BookClubMemberEntity bookClubMemberEntity = bookClubMemberEntityRepository.findByBookClubIdAndUserId(bookClubId, userId);
+        bookClubMemberEntity.inactivate();
+    }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubEntity.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubEntity.java
@@ -29,6 +29,7 @@ public class BookClubEntity {
     private int memberLimit;
     private String city;
     private String town;
+    private Long createdBy;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -46,6 +47,7 @@ public class BookClubEntity {
             int memberLimit,
             String city,
             String town,
+            Long createdBy,
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {
@@ -58,6 +60,7 @@ public class BookClubEntity {
         this.memberLimit = memberLimit;
         this.city = city;
         this.town = town;
+        this.createdBy = createdBy;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
@@ -73,12 +76,13 @@ public class BookClubEntity {
                 .memberLimit(bookClub.getMemberLimit())
                 .city(bookClub.getCity())
                 .town(bookClub.getTown())
+                .createdBy(bookClub.getCreatedBy())
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .build();
     }
 
     public BookClub toModel() {
-        return BookClub.of(id, description, title, meetingType, bookClubType, targetDate, endDate, memberLimit, city, town);
+        return BookClub.of(id, description, title, meetingType, bookClubType, targetDate, endDate, memberLimit, city, town, createdBy);
     }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubEntity.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubEntity.java
@@ -1,0 +1,67 @@
+package com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity;
+
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
+import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+public class BookClubEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String title;
+    private BookClubType bookClubType;
+    private LocalDate targetDate;
+    private LocalDate endDate;
+    private int memberLimit;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    protected BookClubEntity() {
+    }
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private BookClubEntity(
+            String title,
+            BookClubType bookClubType,
+            LocalDate targetDate,
+            LocalDate endDate,
+            int memberLimit,
+            LocalDateTime createdAt,
+            LocalDateTime updatedAt
+    ) {
+        this.title = title;
+        this.bookClubType = bookClubType;
+        this.targetDate = targetDate;
+        this.endDate = endDate;
+        this.memberLimit = memberLimit;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static BookClubEntity from(BookClub bookClub) {
+        return BookClubEntity.builder()
+                .title(bookClub.getTitle())
+                .bookClubType(bookClub.getBookClubType())
+                .targetDate(bookClub.getTargetDate())
+                .endDate(bookClub.getEndDate())
+                .memberLimit(bookClub.getMemberLimit())
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public BookClub toModel() {
+        return BookClub.of(id, title, bookClubType, targetDate, endDate, memberLimit);
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubEntity.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubEntity.java
@@ -2,7 +2,7 @@ package com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity;
 
 import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
 import com.codeit.sprint.team3.backend.bookclub.domain.MeetingType;
-import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClub;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubEntity.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubEntity.java
@@ -1,6 +1,7 @@
 package com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity;
 
 import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
+import com.codeit.sprint.team3.backend.bookclub.domain.MeetingType;
 import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -20,6 +21,8 @@ public class BookClubEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String title;
+    private String description;
+    private MeetingType meetingType;
     private BookClubType bookClubType;
     private LocalDate targetDate;
     private LocalDate endDate;
@@ -35,6 +38,8 @@ public class BookClubEntity {
     @Builder(access = AccessLevel.PRIVATE)
     private BookClubEntity(
             String title,
+            String description,
+            MeetingType meetingType,
             BookClubType bookClubType,
             LocalDate targetDate,
             LocalDate endDate,
@@ -45,6 +50,8 @@ public class BookClubEntity {
             LocalDateTime updatedAt
     ) {
         this.title = title;
+        this.description = description;
+        this.meetingType = meetingType;
         this.bookClubType = bookClubType;
         this.targetDate = targetDate;
         this.endDate = endDate;
@@ -58,6 +65,8 @@ public class BookClubEntity {
     public static BookClubEntity from(BookClub bookClub) {
         return BookClubEntity.builder()
                 .title(bookClub.getTitle())
+                .description(bookClub.getDescription())
+                .meetingType(bookClub.getMeetingType())
                 .bookClubType(bookClub.getBookClubType())
                 .targetDate(bookClub.getTargetDate())
                 .endDate(bookClub.getEndDate())
@@ -70,6 +79,6 @@ public class BookClubEntity {
     }
 
     public BookClub toModel() {
-        return BookClub.of(id, title, bookClubType, targetDate, endDate, memberLimit, city, town);
+        return BookClub.of(id, description, title, meetingType, bookClubType, targetDate, endDate, memberLimit, city, town);
     }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubEntity.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubEntity.java
@@ -24,6 +24,8 @@ public class BookClubEntity {
     private LocalDate targetDate;
     private LocalDate endDate;
     private int memberLimit;
+    private String city;
+    private String town;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
@@ -37,6 +39,8 @@ public class BookClubEntity {
             LocalDate targetDate,
             LocalDate endDate,
             int memberLimit,
+            String city,
+            String town,
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {
@@ -45,6 +49,8 @@ public class BookClubEntity {
         this.targetDate = targetDate;
         this.endDate = endDate;
         this.memberLimit = memberLimit;
+        this.city = city;
+        this.town = town;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
     }
@@ -56,12 +62,14 @@ public class BookClubEntity {
                 .targetDate(bookClub.getTargetDate())
                 .endDate(bookClub.getEndDate())
                 .memberLimit(bookClub.getMemberLimit())
+                .city(bookClub.getCity())
+                .town(bookClub.getTown())
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .build();
     }
 
     public BookClub toModel() {
-        return BookClub.of(id, title, bookClubType, targetDate, endDate, memberLimit);
+        return BookClub.of(id, title, bookClubType, targetDate, endDate, memberLimit, city, town);
     }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubEntity.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubEntity.java
@@ -65,7 +65,7 @@ public class BookClubEntity {
         this.updatedAt = updatedAt;
     }
 
-    public static BookClubEntity from(BookClub bookClub) {
+    public static BookClubEntity of(BookClub bookClub, Long userId) {
         return BookClubEntity.builder()
                 .title(bookClub.getTitle())
                 .description(bookClub.getDescription())
@@ -76,7 +76,7 @@ public class BookClubEntity {
                 .memberLimit(bookClub.getMemberLimit())
                 .city(bookClub.getCity())
                 .town(bookClub.getTown())
-                .createdBy(bookClub.getCreatedBy())
+                .createdBy(userId)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .build();

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubLikeEntity.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubLikeEntity.java
@@ -1,0 +1,28 @@
+package com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity;
+
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClubLike;
+import jakarta.persistence.*;
+
+@Entity
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"bookClubId", "userId"})
+})
+public class BookClubLikeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long bookClubId;
+    private Long userId;
+
+    protected BookClubLikeEntity() {
+    }
+
+    public BookClubLikeEntity(Long bookClubId, Long userId) {
+        this.bookClubId = bookClubId;
+        this.userId = userId;
+    }
+
+    public static BookClubLikeEntity from(BookClubLike bookClubLike) {
+        return new BookClubLikeEntity(bookClubLike.getBookClubId(), bookClubLike.getUserId());
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubMemberEntity.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubMemberEntity.java
@@ -30,4 +30,12 @@ public class BookClubMemberEntity {
     public static BookClubMemberEntity from(Member member) {
         return new BookClubMemberEntity(member.getBookClubId(), member.getUserId());
     }
+
+    public static BookClubMemberEntity of(Long bookClubId, Long userId) {
+        return new BookClubMemberEntity(bookClubId, userId);
+    }
+
+    public void inactivate() {
+        isInactive = true;
+    }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubMemberEntity.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubMemberEntity.java
@@ -1,12 +1,10 @@
 package com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity;
 
-import com.codeit.sprint.team3.backend.bookclub.domain.model.Member;
+import com.codeit.sprint.team3.backend.bookclub.domain.Member;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 
 @Entity

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubMemberEntity.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubMemberEntity.java
@@ -1,0 +1,32 @@
+package com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity;
+
+import com.codeit.sprint.team3.backend.bookclub.domain.model.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class BookClubMemberEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long bookClubId;
+    private Long userId;
+
+    protected BookClubMemberEntity() {
+    }
+
+    private BookClubMemberEntity(Long bookClubId, Long userId) {
+        this.bookClubId = bookClubId;
+        this.userId = userId;
+    }
+
+    public static BookClubMemberEntity from(Member member) {
+        return new BookClubMemberEntity(member.getBookClubId(), member.getUserId());
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubMemberEntity.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/entity/BookClubMemberEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.Getter;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -15,6 +16,8 @@ public class BookClubMemberEntity {
     private Long id;
     private Long bookClubId;
     private Long userId;
+    @ColumnDefault("false")
+    private boolean isInactive;
 
     protected BookClubMemberEntity() {
     }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/repository/BookClubDto.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/repository/BookClubDto.java
@@ -1,0 +1,46 @@
+package com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.repository;
+
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClub;
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
+import com.codeit.sprint.team3.backend.bookclub.domain.MeetingType;
+import com.querydsl.core.annotations.QueryProjection;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class BookClubDto {
+    private final Long id;
+    private final String title;
+    private final String description;
+    private final MeetingType meetingType;
+    private final BookClubType bookClubType;
+    private final LocalDate targetDate;
+    private final LocalDate endDate;
+    private final int memberLimit;
+    private final String city;
+    private final String town;
+    private final Long createdBy;
+    private final LocalDateTime createdAt;
+    private final Integer memberCount;
+
+    @QueryProjection
+    public BookClubDto(Long id, String title, String description, MeetingType meetingType, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit, String city, String town, Long createdBy, LocalDateTime createdAt, int memberCount) {
+        this.id = id;
+        this.title = title;
+        this.description = description;
+        this.meetingType = meetingType;
+        this.bookClubType = bookClubType;
+        this.targetDate = targetDate;
+        this.endDate = endDate;
+        this.memberLimit = memberLimit;
+        this.city = city;
+        this.town = town;
+        this.createdBy = createdBy;
+        this.createdAt = createdAt;
+        this.memberCount = memberCount;
+    }
+
+    public BookClub toModel() {
+        return BookClub.of(id, title, description, meetingType, bookClubType, targetDate, endDate, memberLimit, city, town, createdBy, memberCount);
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/repository/BookClubEntityRepository.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/repository/BookClubEntityRepository.java
@@ -1,0 +1,7 @@
+package com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.repository;
+
+import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity.BookClubEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookClubEntityRepository extends JpaRepository<BookClubEntity, Long> {
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/repository/BookClubLikeEntityRepository.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/repository/BookClubLikeEntityRepository.java
@@ -1,0 +1,10 @@
+package com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.repository;
+
+import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity.BookClubLikeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BookClubLikeEntityRepository extends JpaRepository<BookClubLikeEntity, Long> {
+    Optional<BookClubLikeEntity> findByBookClubIdAndUserId(Long bookClubId, Long userId);
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/repository/BookClubMemberEntityRepository.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/repository/BookClubMemberEntityRepository.java
@@ -4,4 +4,7 @@ import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity.B
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookClubMemberEntityRepository extends JpaRepository<BookClubMemberEntity, Integer> {
+    boolean existsByBookClubIdAndUserIdAndIsInactiveFalse(Long bookClubId, Long userId);
+
+    BookClubMemberEntity findByBookClubIdAndUserId(Long bookClubId, Long userId);
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/repository/BookClubMemberEntityRepository.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/repository/BookClubMemberEntityRepository.java
@@ -1,0 +1,7 @@
+package com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.repository;
+
+import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity.BookClubMemberEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookClubMemberEntityRepository extends JpaRepository<BookClubMemberEntity, Integer> {
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/repository/BookClubQueryRepository.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/repository/BookClubQueryRepository.java
@@ -25,7 +25,7 @@ public class BookClubQueryRepository {
         BooleanBuilder builder = new BooleanBuilder();
 
         if (!StringUtils.isNullOrEmpty(location)) {
-            builder.and(bookClubEntity.city.eq(location));
+            builder.and(bookClubEntity.town.eq(location));
         }
         if (memberLimit != null) {
             builder.and(bookClubEntity.memberLimit.eq(memberLimit));

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/repository/BookClubQueryRepository.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/adapter/out/persistence/repository/BookClubQueryRepository.java
@@ -1,0 +1,50 @@
+package com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.repository;
+
+import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity.BookClubEntity;
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
+import com.codeit.sprint.team3.backend.bookclub.domain.MeetingType;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.EnumPath;
+import com.querydsl.core.util.StringUtils;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity.QBookClubEntity.bookClubEntity;
+
+@RequiredArgsConstructor
+@Repository
+public class BookClubQueryRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<BookClubEntity> findBookClubsBy(BookClubType bookClubType, MeetingType meetingType, Integer memberLimit, String location, LocalDate targetDate) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (!StringUtils.isNullOrEmpty(location)) {
+            builder.and(bookClubEntity.city.eq(location));
+        }
+        if (memberLimit != null) {
+            builder.and(bookClubEntity.memberLimit.eq(memberLimit));
+        }
+        if (targetDate != null) {
+            builder.and(bookClubEntity.targetDate.eq(targetDate));
+        }
+        return jpaQueryFactory.selectFrom(bookClubEntity)
+                .where(
+                        filterEnum(bookClubType, bookClubEntity.bookClubType),
+                        filterEnum(meetingType, bookClubEntity.meetingType),
+                        builder)
+                .fetch();
+    }
+
+    private <T extends Enum<T>> BooleanExpression filterEnum(T enumValue, EnumPath<T> enumPath) {
+        if (enumValue.name().equals("ALL")) {
+            return null;
+        }
+        return enumPath.eq(enumValue);
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/BookClubLikeUseCase.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/BookClubLikeUseCase.java
@@ -1,7 +1,11 @@
 package com.codeit.sprint.team3.backend.bookclub.application.port.in;
 
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClub;
+
 public interface BookClubLikeUseCase {
     void saveBookClubLike(Long bookClubId, Long userId);
 
     void deleteBookClubLike(Long bookClubId, Long userId);
+
+    BookClub getBookClubById(Long bookClubId);
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/BookClubLikeUseCase.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/BookClubLikeUseCase.java
@@ -1,0 +1,7 @@
+package com.codeit.sprint.team3.backend.bookclub.application.port.in;
+
+public interface BookClubLikeUseCase {
+    void saveBookClubLike(Long bookClubId, Long userId);
+
+    void deleteBookClubLike(Long bookClubId, Long userId);
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/BookClubMemberUseCase.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/BookClubMemberUseCase.java
@@ -1,6 +1,6 @@
 package com.codeit.sprint.team3.backend.bookclub.application.port.in;
 
-import com.codeit.sprint.team3.backend.bookclub.domain.model.Member;
+import com.codeit.sprint.team3.backend.bookclub.domain.Member;
 
 public interface BookClubMemberUseCase {
     void saveMember(Member member);

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/BookClubMemberUseCase.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/BookClubMemberUseCase.java
@@ -4,4 +4,8 @@ import com.codeit.sprint.team3.backend.bookclub.domain.Member;
 
 public interface BookClubMemberUseCase {
     void saveMember(Member member);
+
+    void joinBookClub(Long bookClubId, Long userId);
+
+    void leaveBookClub(Long bookClubId, Long userId);
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/BookClubMemberUseCase.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/BookClubMemberUseCase.java
@@ -1,0 +1,7 @@
+package com.codeit.sprint.team3.backend.bookclub.application.port.in;
+
+import com.codeit.sprint.team3.backend.bookclub.domain.model.Member;
+
+public interface BookClubMemberUseCase {
+    void saveMember(Member member);
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/BookClubUseCase.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/BookClubUseCase.java
@@ -2,7 +2,7 @@ package com.codeit.sprint.team3.backend.bookclub.application.port.in;
 
 import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
 import com.codeit.sprint.team3.backend.bookclub.domain.MeetingType;
-import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClub;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/BookClubUseCase.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/BookClubUseCase.java
@@ -1,0 +1,7 @@
+package com.codeit.sprint.team3.backend.bookclub.application.port.in;
+
+import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
+
+public interface BookClubUseCase {
+    void createBookClub(BookClub bookClub);
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/BookClubUseCase.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/BookClubUseCase.java
@@ -1,7 +1,14 @@
 package com.codeit.sprint.team3.backend.bookclub.application.port.in;
 
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
+import com.codeit.sprint.team3.backend.bookclub.domain.MeetingType;
 import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
+
+import java.time.LocalDate;
+import java.util.List;
 
 public interface BookClubUseCase {
     void createBookClub(BookClub bookClub);
+
+    List<BookClub> findBookClubsBy(BookClubType bookClubType, MeetingType meetingType, Integer memberLimit, String location, LocalDate targetDate);
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/BookClubUseCase.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/BookClubUseCase.java
@@ -8,7 +8,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 public interface BookClubUseCase {
-    void createBookClub(BookClub bookClub);
+    void createBookClub(BookClub bookClub, Long userId);
 
     List<BookClub> findBookClubsBy(BookClubType bookClubType, MeetingType meetingType, Integer memberLimit, String location, LocalDate targetDate);
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/BookmarkBookClubUseCase.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/BookmarkBookClubUseCase.java
@@ -1,4 +1,0 @@
-package com.codeit.sprint.team3.backend.bookclub.application.port.in;
-
-public interface BookmarkBookClubUseCase {
-}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/CancelBookClubUseCase.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/CancelBookClubUseCase.java
@@ -1,4 +1,0 @@
-package com.codeit.sprint.team3.backend.bookclub.application.port.in;
-
-public interface CancelBookClubUseCase {
-}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/CreateBookClubUseCase.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/CreateBookClubUseCase.java
@@ -1,4 +1,0 @@
-package com.codeit.sprint.team3.backend.bookclub.application.port.in;
-
-public interface CreateBookClubUseCase {
-}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/JoinBookClubUseCase.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/JoinBookClubUseCase.java
@@ -1,4 +1,0 @@
-package com.codeit.sprint.team3.backend.bookclub.application.port.in;
-
-public interface JoinBookClubUseCase {
-}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/ViewBookClubListUseCase.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/in/ViewBookClubListUseCase.java
@@ -1,4 +1,0 @@
-package com.codeit.sprint.team3.backend.bookclub.application.port.in;
-
-public interface ViewBookClubListUseCase {
-}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/BookClubLikePort.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/BookClubLikePort.java
@@ -1,0 +1,9 @@
+package com.codeit.sprint.team3.backend.bookclub.application.port.out;
+
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClubLike;
+
+public interface BookClubLikePort {
+    void saveBookClubLike(BookClubLike bookClubLike);
+
+    void deleteBookClubLike(BookClubLike bookClubLike);
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/CommandBookClubMemberPort.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/CommandBookClubMemberPort.java
@@ -1,0 +1,7 @@
+package com.codeit.sprint.team3.backend.bookclub.application.port.out;
+
+import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity.BookClubMemberEntity;
+
+public interface CommandBookClubMemberPort {
+    void save(BookClubMemberEntity from);
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/CommandBookClubMemberPort.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/CommandBookClubMemberPort.java
@@ -4,4 +4,10 @@ import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity.B
 
 public interface CommandBookClubMemberPort {
     void save(BookClubMemberEntity from);
+
+    boolean existsByBookClubIdAndUserId(Long bookClubId, Long userId);
+
+    void joinBookClub(Long bookClubId, Long userId);
+
+    void leaveBookClub(Long bookClubId, Long userId);
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/CommandBookClubPort.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/CommandBookClubPort.java
@@ -3,5 +3,5 @@ package com.codeit.sprint.team3.backend.bookclub.application.port.out;
 import com.codeit.sprint.team3.backend.bookclub.domain.BookClub;
 
 public interface CommandBookClubPort {
-    BookClub saveBookClub(BookClub bookClub);
+    BookClub saveBookClub(BookClub bookClub, Long userId);
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/CommandBookClubPort.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/CommandBookClubPort.java
@@ -1,6 +1,6 @@
 package com.codeit.sprint.team3.backend.bookclub.application.port.out;
 
-import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClub;
 
 public interface CommandBookClubPort {
     BookClub saveBookClub(BookClub bookClub);

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/CommandBookClubPort.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/CommandBookClubPort.java
@@ -1,0 +1,7 @@
+package com.codeit.sprint.team3.backend.bookclub.application.port.out;
+
+import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
+
+public interface CommandBookClubPort {
+    BookClub saveBookClub(BookClub bookClub);
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/QueryBookClubPort.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/QueryBookClubPort.java
@@ -6,7 +6,10 @@ import com.codeit.sprint.team3.backend.bookclub.domain.BookClub;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface QueryBookClubPort {
     List<BookClub> findBookClubsBy(BookClubType bookClubType, MeetingType meetingType, Integer memberLimit, String location, LocalDate targetDate);
+
+    Optional<BookClub> getById(Long bookClubId);
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/QueryBookClubPort.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/QueryBookClubPort.java
@@ -1,4 +1,4 @@
 package com.codeit.sprint.team3.backend.bookclub.application.port.out;
 
-public interface LoadBookClubPort {
+public interface QueryBookClubPort {
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/QueryBookClubPort.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/QueryBookClubPort.java
@@ -1,4 +1,12 @@
 package com.codeit.sprint.team3.backend.bookclub.application.port.out;
 
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
+import com.codeit.sprint.team3.backend.bookclub.domain.MeetingType;
+import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
+
+import java.time.LocalDate;
+import java.util.List;
+
 public interface QueryBookClubPort {
+    List<BookClub> findBookClubsBy(BookClubType bookClubType, MeetingType meetingType, Integer memberLimit, String location, LocalDate targetDate);
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/QueryBookClubPort.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/QueryBookClubPort.java
@@ -2,7 +2,7 @@ package com.codeit.sprint.team3.backend.bookclub.application.port.out;
 
 import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
 import com.codeit.sprint.team3.backend.bookclub.domain.MeetingType;
-import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClub;
 
 import java.time.LocalDate;
 import java.util.List;

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/SaveBookClubPort.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/port/out/SaveBookClubPort.java
@@ -1,4 +1,0 @@
-package com.codeit.sprint.team3.backend.bookclub.application.port.out;
-
-public interface SaveBookClubPort {
-}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubLikeService.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubLikeService.java
@@ -1,0 +1,34 @@
+package com.codeit.sprint.team3.backend.bookclub.application.service;
+
+import com.codeit.sprint.team3.backend.bookclub.adapter.exception.BookClubNotExistException;
+import com.codeit.sprint.team3.backend.bookclub.application.port.in.BookClubLikeUseCase;
+import com.codeit.sprint.team3.backend.bookclub.application.port.out.BookClubLikePort;
+import com.codeit.sprint.team3.backend.bookclub.application.port.out.QueryBookClubPort;
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClub;
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClubLike;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BookClubLikeService implements BookClubLikeUseCase {
+    private final QueryBookClubPort queryBookClubPort;
+    private final BookClubLikePort bookClubLikePort;
+
+    @Override
+    public void saveBookClubLike(Long bookClubId, Long userId) {
+        BookClub bookClub = getBookClubById(bookClubId);
+        bookClubLikePort.saveBookClubLike(BookClubLike.of(bookClub.getId(), userId));
+    }
+
+    @Override
+    public void deleteBookClubLike(Long bookClubId, Long userId) {
+        BookClub bookClub = getBookClubById(bookClubId);
+        bookClubLikePort.deleteBookClubLike(BookClubLike.of(bookClub.getId(), userId));
+    }
+
+    private BookClub getBookClubById(Long bookClubId) {
+        return queryBookClubPort.getById(bookClubId)
+                .orElseThrow(BookClubNotExistException::new);
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubLikeService.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubLikeService.java
@@ -27,7 +27,8 @@ public class BookClubLikeService implements BookClubLikeUseCase {
         bookClubLikePort.deleteBookClubLike(BookClubLike.of(bookClub.getId(), userId));
     }
 
-    private BookClub getBookClubById(Long bookClubId) {
+    @Override
+    public BookClub getBookClubById(Long bookClubId) {
         return queryBookClubPort.getById(bookClubId)
                 .orElseThrow(BookClubNotExistException::new);
     }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubMemberService.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubMemberService.java
@@ -3,7 +3,7 @@ package com.codeit.sprint.team3.backend.bookclub.application.service;
 import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity.BookClubMemberEntity;
 import com.codeit.sprint.team3.backend.bookclub.application.port.out.CommandBookClubMemberPort;
 import com.codeit.sprint.team3.backend.bookclub.application.port.in.BookClubMemberUseCase;
-import com.codeit.sprint.team3.backend.bookclub.domain.model.Member;
+import com.codeit.sprint.team3.backend.bookclub.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubMemberService.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubMemberService.java
@@ -34,6 +34,8 @@ public class BookClubMemberService implements BookClubMemberUseCase {
         //BookClub에 가입
         //TODO 동시성 문제가 생길 수 있으므로 Lock 필요. 어떻게 구현할것인가?
         commandBookClubMemberPort.joinBookClub(bookClubId, userId);
+        //TODO 채팅방에 멤버 추가
+        //TODO 알림
     }
 
     @Override
@@ -47,7 +49,9 @@ public class BookClubMemberService implements BookClubMemberUseCase {
         /**
          * TODO
          * 1. 남은 유저가 없다면 BookClub 삭제
-         * 2. 남은 유저가 없다면 채팅방 삭제
+         * 2. 채팅방에서 멤버 제거
+         * 3. 알림
+         * 4. 남은 유저가 없다면 채팅방 삭제 및 북클럽 삭제
          */
     }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubMemberService.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubMemberService.java
@@ -1,0 +1,19 @@
+package com.codeit.sprint.team3.backend.bookclub.application.service;
+
+import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity.BookClubMemberEntity;
+import com.codeit.sprint.team3.backend.bookclub.application.port.out.CommandBookClubMemberPort;
+import com.codeit.sprint.team3.backend.bookclub.application.port.in.BookClubMemberUseCase;
+import com.codeit.sprint.team3.backend.bookclub.domain.model.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BookClubMemberService implements BookClubMemberUseCase {
+    private final CommandBookClubMemberPort commandBookClubMemberPort;
+
+    @Override
+    public void saveMember(Member member) {
+        commandBookClubMemberPort.save(BookClubMemberEntity.from(member));
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubMemberService.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubMemberService.java
@@ -1,19 +1,53 @@
 package com.codeit.sprint.team3.backend.bookclub.application.service;
 
+import com.codeit.sprint.team3.backend.bookclub.adapter.exception.BookClubMemberAlreadyExistsException;
 import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity.BookClubMemberEntity;
+import com.codeit.sprint.team3.backend.bookclub.application.port.in.BookClubLikeUseCase;
 import com.codeit.sprint.team3.backend.bookclub.application.port.out.CommandBookClubMemberPort;
 import com.codeit.sprint.team3.backend.bookclub.application.port.in.BookClubMemberUseCase;
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClub;
 import com.codeit.sprint.team3.backend.bookclub.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class BookClubMemberService implements BookClubMemberUseCase {
     private final CommandBookClubMemberPort commandBookClubMemberPort;
+    private final BookClubLikeUseCase bookClubLikeUseCase;
 
     @Override
     public void saveMember(Member member) {
         commandBookClubMemberPort.save(BookClubMemberEntity.from(member));
+    }
+
+    @Override
+    @Transactional
+    public void joinBookClub(Long bookClubId, Long userId) {
+        //존재하는 BookClub인지 확인
+        BookClub bookClub = bookClubLikeUseCase.getBookClubById(bookClubId);
+        //이미 가입한 BookClub인지 확인
+        if (commandBookClubMemberPort.existsByBookClubIdAndUserId(bookClubId, userId)) {
+            throw new BookClubMemberAlreadyExistsException();
+        }
+        //BookClub에 가입
+        //TODO 동시성 문제가 생길 수 있으므로 Lock 필요. 어떻게 구현할것인가?
+        commandBookClubMemberPort.joinBookClub(bookClubId, userId);
+    }
+
+    @Override
+    @Transactional
+    public void leaveBookClub(Long bookClubId, Long userId) {
+        //존재하는 BookClub인지 확인
+        BookClub bookClub = bookClubLikeUseCase.getBookClubById(bookClubId);
+        //BookClub에서 탈퇴
+        commandBookClubMemberPort.leaveBookClub(bookClub.getId(), userId);
+
+        /**
+         * TODO
+         * 1. 남은 유저가 없다면 BookClub 삭제
+         * 2. 남은 유저가 없다면 채팅방 삭제
+         */
     }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubService.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubService.java
@@ -1,0 +1,35 @@
+package com.codeit.sprint.team3.backend.bookclub.application.service;
+
+import com.codeit.sprint.team3.backend.bookclub.application.port.in.BookClubMemberUseCase;
+import com.codeit.sprint.team3.backend.bookclub.application.port.in.BookClubUseCase;
+import com.codeit.sprint.team3.backend.bookclub.application.port.out.CommandBookClubPort;
+import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
+import com.codeit.sprint.team3.backend.bookclub.domain.model.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BookClubService implements BookClubUseCase {
+    private final CommandBookClubPort commandBookClubPort;
+    private final BookClubMemberUseCase bookClubMemberUseCase;
+
+    @Override
+    public void createBookClub(BookClub bookClub) {
+        //TODO 유저 security context에서 아이디 가져오기
+        Long userId = 1L;
+
+        //book club creation logic
+        BookClub savedBookClub = commandBookClubPort.saveBookClub(bookClub);
+
+        Member member = Member.of(savedBookClub.getId(), userId);
+        bookClubMemberUseCase.saveMember(member);
+
+        /**
+         * TODO 채팅 구현되면 아래 로직 추가하기
+         * 채팅방 생성
+         * 채팅방에 멤버 추가(북클럽 생성자)
+         * 알림
+         */
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubService.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubService.java
@@ -6,8 +6,8 @@ import com.codeit.sprint.team3.backend.bookclub.application.port.out.CommandBook
 import com.codeit.sprint.team3.backend.bookclub.application.port.out.QueryBookClubPort;
 import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
 import com.codeit.sprint.team3.backend.bookclub.domain.MeetingType;
-import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
-import com.codeit.sprint.team3.backend.bookclub.domain.model.Member;
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClub;
+import com.codeit.sprint.team3.backend.bookclub.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubService.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubService.java
@@ -22,12 +22,9 @@ public class BookClubService implements BookClubUseCase {
     private final BookClubMemberUseCase bookClubMemberUseCase;
 
     @Override
-    public void createBookClub(BookClub bookClub) {
-        //TODO 유저 security context에서 아이디 가져오기
-        Long userId = 1L;
-
+    public void createBookClub(BookClub bookClub, Long userId) {
         //book club creation logic
-        BookClub savedBookClub = commandBookClubPort.saveBookClub(bookClub);
+        BookClub savedBookClub = commandBookClubPort.saveBookClub(bookClub, userId);
 
         //save the creator as a member
         bookClubMemberUseCase.saveMember(Member.of(savedBookClub.getId(), userId));

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubService.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubService.java
@@ -29,8 +29,8 @@ public class BookClubService implements BookClubUseCase {
         //book club creation logic
         BookClub savedBookClub = commandBookClubPort.saveBookClub(bookClub);
 
-        Member member = Member.of(savedBookClub.getId(), userId);
-        bookClubMemberUseCase.saveMember(member);
+        //save the creator as a member
+        bookClubMemberUseCase.saveMember(Member.of(savedBookClub.getId(), userId));
 
         /**
          * TODO 채팅 구현되면 아래 로직 추가하기

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubService.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookClubService.java
@@ -3,15 +3,22 @@ package com.codeit.sprint.team3.backend.bookclub.application.service;
 import com.codeit.sprint.team3.backend.bookclub.application.port.in.BookClubMemberUseCase;
 import com.codeit.sprint.team3.backend.bookclub.application.port.in.BookClubUseCase;
 import com.codeit.sprint.team3.backend.bookclub.application.port.out.CommandBookClubPort;
+import com.codeit.sprint.team3.backend.bookclub.application.port.out.QueryBookClubPort;
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
+import com.codeit.sprint.team3.backend.bookclub.domain.MeetingType;
 import com.codeit.sprint.team3.backend.bookclub.domain.model.BookClub;
 import com.codeit.sprint.team3.backend.bookclub.domain.model.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class BookClubService implements BookClubUseCase {
     private final CommandBookClubPort commandBookClubPort;
+    private final QueryBookClubPort queryBookClubPort;
     private final BookClubMemberUseCase bookClubMemberUseCase;
 
     @Override
@@ -31,5 +38,10 @@ public class BookClubService implements BookClubUseCase {
          * 채팅방에 멤버 추가(북클럽 생성자)
          * 알림
          */
+    }
+
+    @Override
+    public List<BookClub> findBookClubsBy(BookClubType bookClubType, MeetingType meetingType, Integer memberLimit, String location, LocalDate targetDate) {
+        return queryBookClubPort.findBookClubsBy(bookClubType, meetingType, memberLimit, location, targetDate);
     }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookmarkBookClubService.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/BookmarkBookClubService.java
@@ -1,6 +1,0 @@
-package com.codeit.sprint.team3.backend.bookclub.application.service;
-
-import com.codeit.sprint.team3.backend.bookclub.application.port.in.BookmarkBookClubUseCase;
-
-public class BookmarkBookClubService implements BookmarkBookClubUseCase {
-}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/CancelBookClubService.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/CancelBookClubService.java
@@ -1,6 +1,0 @@
-package com.codeit.sprint.team3.backend.bookclub.application.service;
-
-import com.codeit.sprint.team3.backend.bookclub.application.port.in.CancelBookClubUseCase;
-
-public class CancelBookClubService implements CancelBookClubUseCase {
-}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/CreateBookClubService.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/CreateBookClubService.java
@@ -1,6 +1,0 @@
-package com.codeit.sprint.team3.backend.bookclub.application.service;
-
-import com.codeit.sprint.team3.backend.bookclub.application.port.in.CreateBookClubUseCase;
-
-public class CreateBookClubService implements CreateBookClubUseCase {
-}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/JoinBookClubService.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/JoinBookClubService.java
@@ -1,6 +1,0 @@
-package com.codeit.sprint.team3.backend.bookclub.application.service;
-
-import com.codeit.sprint.team3.backend.bookclub.application.port.in.JoinBookClubUseCase;
-
-public class JoinBookClubService implements JoinBookClubUseCase {
-}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/ViewBookClubListService.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/application/service/ViewBookClubListService.java
@@ -1,6 +1,0 @@
-package com.codeit.sprint.team3.backend.bookclub.application.service;
-
-import com.codeit.sprint.team3.backend.bookclub.application.port.in.ViewBookClubListUseCase;
-
-public class ViewBookClubListService implements ViewBookClubListUseCase {
-}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/BookClub.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/BookClub.java
@@ -1,5 +1,6 @@
 package com.codeit.sprint.team3.backend.bookclub.domain;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -17,9 +18,10 @@ public class BookClub {
     private final int memberLimit;
     private final String city;
     private final String town;
+    private final Long createdBy;
 
-    @Builder
-    private BookClub(Long id, String description, String title, MeetingType meetingType, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit, String city, String town) {
+    @Builder(access = AccessLevel.PRIVATE)
+    private BookClub(Long id, String description, String title, MeetingType meetingType, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit, String city, String town, Long createdBy) {
         this.id = id;
         this.title = title;
         this.description = description;
@@ -30,6 +32,7 @@ public class BookClub {
         this.memberLimit = memberLimit;
         this.city = city;
         this.town = town;
+        this.createdBy = createdBy;
     }
 
     public static BookClub of(String title, String description, MeetingType meetingType, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit, String city, String town) {
@@ -46,7 +49,7 @@ public class BookClub {
                 .build();
     }
 
-    public static BookClub of(Long id, String title, String description, MeetingType meetingType, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit, String city, String town) {
+    public static BookClub of(Long id, String title, String description, MeetingType meetingType, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit, String city, String town, Long createdBy) {
         return BookClub.builder()
                 .id(id)
                 .title(title)
@@ -58,6 +61,7 @@ public class BookClub {
                 .memberLimit(memberLimit)
                 .city(city)
                 .town(town)
+                .createdBy(createdBy)
                 .build();
     }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/BookClub.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/BookClub.java
@@ -19,9 +19,10 @@ public class BookClub {
     private final String city;
     private final String town;
     private final Long createdBy;
+    private final int memberCount;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private BookClub(Long id, String description, String title, MeetingType meetingType, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit, String city, String town, Long createdBy) {
+    private BookClub(Long id, String description, String title, MeetingType meetingType, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit, String city, String town, Long createdBy, int memberCount) {
         this.id = id;
         this.title = title;
         this.description = description;
@@ -33,6 +34,7 @@ public class BookClub {
         this.city = city;
         this.town = town;
         this.createdBy = createdBy;
+        this.memberCount = memberCount;
     }
 
     public static BookClub of(String title, String description, MeetingType meetingType, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit, String city, String town) {
@@ -62,6 +64,23 @@ public class BookClub {
                 .city(city)
                 .town(town)
                 .createdBy(createdBy)
+                .build();
+    }
+
+    public static BookClub of(Long id, String title, String description, MeetingType meetingType, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit, String city, String town, Long createdBy, int memberCount) {
+        return BookClub.builder()
+                .id(id)
+                .title(title)
+                .description(description)
+                .meetingType(meetingType)
+                .bookClubType(bookClubType)
+                .targetDate(targetDate)
+                .endDate(endDate)
+                .memberLimit(memberLimit)
+                .city(city)
+                .town(town)
+                .createdBy(createdBy)
+                .memberCount(memberCount)
                 .build();
     }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/BookClub.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/BookClub.java
@@ -1,7 +1,5 @@
-package com.codeit.sprint.team3.backend.bookclub.domain.model;
+package com.codeit.sprint.team3.backend.bookclub.domain;
 
-import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
-import com.codeit.sprint.team3.backend.bookclub.domain.MeetingType;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/BookClubLike.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/BookClubLike.java
@@ -1,0 +1,24 @@
+package com.codeit.sprint.team3.backend.bookclub.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class BookClubLike {
+    private final Long bookClubId;
+    private final Long userId;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private BookClubLike(Long bookClubId, Long userId) {
+        this.bookClubId = bookClubId;
+        this.userId = userId;
+    }
+
+    public static BookClubLike of(Long bookClubId, Long userId) {
+        return BookClubLike.builder()
+                .bookClubId(bookClubId)
+                .userId(userId)
+                .build();
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/BookClubType.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/BookClubType.java
@@ -1,0 +1,15 @@
+package com.codeit.sprint.team3.backend.bookclub.domain;
+
+public enum BookClubType {
+    FREE,
+    FIXED
+    ;
+
+    public static BookClubType from(String type) {
+        return switch (type.toUpperCase()) {
+            case "FREE" -> FREE;
+            case "FIXED" -> FIXED;
+            default -> throw new IllegalArgumentException("변환할 수 없는 타입입니다.: " + type);
+        };
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/MeetingType.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/MeetingType.java
@@ -1,23 +1,23 @@
 package com.codeit.sprint.team3.backend.bookclub.domain;
 
-public enum BookClubType {
-    FREE,
-    FIXED,
+public enum MeetingType {
+    ONLINE,
+    OFFLINE,
     ALL
     ;
 
-    public static BookClubType getCommandType(String type) {
+    public static MeetingType getCommandType(String type) {
         return switch (type.toUpperCase()) {
-            case "FREE" -> FREE;
-            case "FIXED" -> FIXED;
+            case "ONLINE" -> ONLINE;
+            case "OFFLINE" -> OFFLINE;
             default -> throw new IllegalArgumentException("변환할 수 없는 타입입니다.: " + type);
         };
     }
 
-    public static BookClubType getQueryType(String type) {
+    public static MeetingType getQueryType(String type) {
         return switch (type.toUpperCase()) {
-            case "FREE" -> FREE;
-            case "FIXED" -> FIXED;
+            case "ONLINE" -> ONLINE;
+            case "OFFLINE" -> OFFLINE;
             case "ALL" -> ALL;
             default -> throw new IllegalArgumentException("변환할 수 없는 타입입니다.: " + type);
         };

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/Member.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/Member.java
@@ -1,4 +1,4 @@
-package com.codeit.sprint.team3.backend.bookclub.domain.model;
+package com.codeit.sprint.team3.backend.bookclub.domain;
 
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/event/BookClubMemberJoinedEvent.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/event/BookClubMemberJoinedEvent.java
@@ -1,5 +1,0 @@
-package com.codeit.sprint.team3.backend.bookclub.domain.event;
-
-public class BookClubMemberJoinedEvent {
-    //이벤트 리스너를 통해 모임채팅에 멤버의 참여를 알린다.
-}

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/model/BookClub.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/model/BookClub.java
@@ -1,4 +1,48 @@
 package com.codeit.sprint.team3.backend.bookclub.domain.model;
 
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
 public class BookClub {
+    private final Long id;
+    private final String title;
+    private final BookClubType bookClubType;
+    private final LocalDate targetDate;
+    private final LocalDate endDate;
+    private final int memberLimit;
+
+    @Builder
+    private BookClub(Long id,String title, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit) {
+        this.id = id;
+        this.title = title;
+        this.bookClubType = bookClubType;
+        this.targetDate = targetDate;
+        this.endDate = endDate;
+        this.memberLimit = memberLimit;
+    }
+
+    public static BookClub of(String title, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit) {
+        return BookClub.builder()
+                .title(title)
+                .bookClubType(bookClubType)
+                .targetDate(targetDate)
+                .endDate(endDate)
+                .memberLimit(memberLimit)
+                .build();
+    }
+
+    public static BookClub of(Long id, String title, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit) {
+        return BookClub.builder()
+                .id(id)
+                .title(title)
+                .bookClubType(bookClubType)
+                .targetDate(targetDate)
+                .endDate(endDate)
+                .memberLimit(memberLimit)
+                .build();
+    }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/model/BookClub.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/model/BookClub.java
@@ -1,6 +1,7 @@
 package com.codeit.sprint.team3.backend.bookclub.domain.model;
 
 import com.codeit.sprint.team3.backend.bookclub.domain.BookClubType;
+import com.codeit.sprint.team3.backend.bookclub.domain.MeetingType;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,6 +11,8 @@ import java.time.LocalDate;
 public class BookClub {
     private final Long id;
     private final String title;
+    private final String description;
+    private final MeetingType meetingType;
     private final BookClubType bookClubType;
     private final LocalDate targetDate;
     private final LocalDate endDate;
@@ -18,9 +21,11 @@ public class BookClub {
     private final String town;
 
     @Builder
-    private BookClub(Long id,String title, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit, String city, String town) {
+    private BookClub(Long id, String description, String title, MeetingType meetingType, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit, String city, String town) {
         this.id = id;
         this.title = title;
+        this.description = description;
+        this.meetingType = meetingType;
         this.bookClubType = bookClubType;
         this.targetDate = targetDate;
         this.endDate = endDate;
@@ -29,9 +34,11 @@ public class BookClub {
         this.town = town;
     }
 
-    public static BookClub of(String title, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit, String city, String town) {
+    public static BookClub of(String title, String description, MeetingType meetingType, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit, String city, String town) {
         return BookClub.builder()
                 .title(title)
+                .description(description)
+                .meetingType(meetingType)
                 .bookClubType(bookClubType)
                 .targetDate(targetDate)
                 .endDate(endDate)
@@ -41,10 +48,12 @@ public class BookClub {
                 .build();
     }
 
-    public static BookClub of(Long id, String title, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit, String city, String town) {
+    public static BookClub of(Long id, String title, String description, MeetingType meetingType, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit, String city, String town) {
         return BookClub.builder()
                 .id(id)
                 .title(title)
+                .description(description)
+                .meetingType(meetingType)
                 .bookClubType(bookClubType)
                 .targetDate(targetDate)
                 .endDate(endDate)

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/model/BookClub.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/model/BookClub.java
@@ -14,28 +14,34 @@ public class BookClub {
     private final LocalDate targetDate;
     private final LocalDate endDate;
     private final int memberLimit;
+    private final String city;
+    private final String town;
 
     @Builder
-    private BookClub(Long id,String title, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit) {
+    private BookClub(Long id,String title, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit, String city, String town) {
         this.id = id;
         this.title = title;
         this.bookClubType = bookClubType;
         this.targetDate = targetDate;
         this.endDate = endDate;
         this.memberLimit = memberLimit;
+        this.city = city;
+        this.town = town;
     }
 
-    public static BookClub of(String title, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit) {
+    public static BookClub of(String title, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit, String city, String town) {
         return BookClub.builder()
                 .title(title)
                 .bookClubType(bookClubType)
                 .targetDate(targetDate)
                 .endDate(endDate)
                 .memberLimit(memberLimit)
+                .city(city)
+                .town(town)
                 .build();
     }
 
-    public static BookClub of(Long id, String title, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit) {
+    public static BookClub of(Long id, String title, BookClubType bookClubType, LocalDate targetDate, LocalDate endDate, int memberLimit, String city, String town) {
         return BookClub.builder()
                 .id(id)
                 .title(title)
@@ -43,6 +49,8 @@ public class BookClub {
                 .targetDate(targetDate)
                 .endDate(endDate)
                 .memberLimit(memberLimit)
+                .city(city)
+                .town(town)
                 .build();
     }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/model/Member.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/model/Member.java
@@ -1,4 +1,24 @@
 package com.codeit.sprint.team3.backend.bookclub.domain.model;
 
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
 public class Member {
+    private final Long bookClubId;
+    private final Long userId;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Member(Long bookClubId, Long userId) {
+        this.bookClubId = bookClubId;
+        this.userId = userId;
+    }
+
+    public static Member of(Long bookClubId, Long userId) {
+        return Member.builder()
+                .bookClubId(bookClubId)
+                .userId(userId)
+                .build();
+    }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/model/MemberShip.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/bookclub/domain/model/MemberShip.java
@@ -1,5 +1,0 @@
-package com.codeit.sprint.team3.backend.bookclub.domain.model;
-
-public class MemberShip {
-    //BookClub과 Member는 Many-To-Many 관계이다.
-}

--- a/src/main/java/com/codeit/sprint/team3/backend/common/config/QueryDslConfig.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/common/config/QueryDslConfig.java
@@ -1,0 +1,23 @@
+package com.codeit.sprint.team3.backend.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public QueryDslConfig() {
+    }
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(this.entityManager);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:tcp://localhost/~/test
+    url: jdbc:h2:mem:test
     driver-class-name: org.h2.Driver
     username: sa
   jpa:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,12 @@ spring:
     multipart:
       max-file-size: 50MB
       max-request-size: 50MB
+  h2:
+    console:
+      enabled: true
+
 logging:
   level:
-    org.hibernate.type: info
+    org.springframework.web.client: DEBUG
+    org.hibernate.sql: DEBUG
+    org.hibernate.orm.jdbc.bind: trace

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,10 @@ spring:
         validator:
           apply_to_ddl: true
         format_sql: true
+  servlet:
+    multipart:
+      max-file-size: 50MB
+      max-request-size: 50MB
 logging:
   level:
     org.hibernate.type: info


### PR DESCRIPTION
하나씩 올릴 예정이었지만.. 너무 늦게 작업이되어서 한번에 올립니다. 죄송합니다 :(

한번 봐주시고 이상한 부분이나 궁금한점, 보완할점 리뷰해주시면 감사하겠습니다!

1. 북클럽 추가
- 사진 업로드 기능 개발 전입니다.
- 채팅기능 생성 후 추가 예정인 기능
  - 채팅방 생성
  - 북클럽 생성자 채팅방에 추가
2. 북클럽 목록 조회
- 조회시 찜 여부 추가 예정
3. 북클럽 참가
- 동시성 컨트롤을 위한 락 추가 필요
- 채팅방 기능 생성 후 추가 예정인 기능
  - 북클럽 생성자 채팅방에 추가
  - 알림
4. 북클럽 나가기
- 남은 유저가 없다면 BookClub 삭제(추후 기능 확인 필요)
- 채팅방 기능 생성 후 추가 예정인 기능
  - 채팅방에서 제거
  - 알림
5. 북클럽 찜하기
6. 북클럽 찜 삭제

## 공통
- 시큐리티 컨텍스트에서 유저 정보 추출 및 유저 정보 확인하는 로직은 추후 추가 예정입니다.