### PR TITLE
feat: 최신 채팅 히스토리 조회 기능 구현

### DIFF
--- a/src/main/java/com/codeit/sprint/team3/backend/chat/adapter/in/web/ChatController.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/chat/adapter/in/web/ChatController.java
@@ -1,6 +1,7 @@
 package com.codeit.sprint.team3.backend.chat.adapter.in.web;
 
 import com.codeit.sprint.team3.backend.auth.domain.model.User;
+import com.codeit.sprint.team3.backend.chat.application.port.in.ChatHistoryUseCase;
 import com.codeit.sprint.team3.backend.chat.application.port.in.SaveChatMessageUseCase;
 import com.codeit.sprint.team3.backend.chat.domain.ChatMessage;
 import com.codeit.sprint.team3.backend.chat.domain.ChatType;
@@ -10,10 +11,12 @@ import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.stereotype.Controller;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Map;
 
 @Controller
@@ -23,7 +26,7 @@ public class ChatController {
     private final SimpMessagingTemplate messagingTemplate;
 
     private final SaveChatMessageUseCase saveChatMessageUseCase;
-
+    private final ChatHistoryUseCase chatHistoryUseCase;
 
     @MessageMapping("/group-chat/{chatRoomId}/sendMessage")
     public void sendMessage(
@@ -48,12 +51,14 @@ public class ChatController {
         saveChatMessageUseCase.save(chatMessage);
     }
 
-    @MessageMapping("/group-chat/getHistory")
-    public void getHistory(
+    @MessageMapping("/group-chat/recent")
+    @SendToUser("/queue/chatHistory")
+    public List<ChatMessage> getHistory(
             @Header(name = "simpSessionAttributes") Map<String, Object> sessionAttributes
     ) {
         User user = (User) sessionAttributes.get("user");
-        //TODO 히스토리 구현
+
+        return chatHistoryUseCase.getRecentClubChatsForUser(user.getId());
     }
 
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/chat/adapter/out/persistence/ChatMessageEntity.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/chat/adapter/out/persistence/ChatMessageEntity.java
@@ -44,4 +44,15 @@ public class ChatMessageEntity {
         );
     }
 
+    public ChatMessage toDomain(){
+        return new ChatMessage(
+                bookClubId,
+                date,
+                userId,
+                userNickname,
+                type,
+                content
+        );
+    }
+
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/chat/adapter/out/persistence/ChatMessageRepository.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/chat/adapter/out/persistence/ChatMessageRepository.java
@@ -3,4 +3,5 @@ package com.codeit.sprint.team3.backend.chat.adapter.out.persistence;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessageEntity, Long> {
+    ChatMessageEntity findTopByBookClubIdOrderByDateDesc(Long bookClubId);
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/chat/adapter/out/persistence/ChatPersistenceAdapter.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/chat/adapter/out/persistence/ChatPersistenceAdapter.java
@@ -1,5 +1,6 @@
 package com.codeit.sprint.team3.backend.chat.adapter.out.persistence;
 
+import com.codeit.sprint.team3.backend.chat.application.port.out.LoadRecentChatsPort;
 import com.codeit.sprint.team3.backend.chat.application.port.out.SaveChatMessagePort;
 import com.codeit.sprint.team3.backend.chat.domain.ChatMessage;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +11,7 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-public class ChatPersistenceAdapter implements SaveChatMessagePort {
+public class ChatPersistenceAdapter implements SaveChatMessagePort, LoadRecentChatsPort {
 
     private final ChatMessageRepository chatMessageRepository;
 
@@ -20,5 +21,11 @@ public class ChatPersistenceAdapter implements SaveChatMessagePort {
         chatMessageRepository.saveAll(
                 list.stream().map(ChatMessageEntity::from).toList()
         );
+    }
+
+    @Override
+    public ChatMessage loadRecentChats(Long bookClubId) {
+        System.out.println("Load recent chats - bookClubId: " + bookClubId);
+        return chatMessageRepository.findTopByBookClubIdOrderByDateDesc(bookClubId).toDomain();
     }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/chat/application/port/in/ChatHistoryUseCase.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/chat/application/port/in/ChatHistoryUseCase.java
@@ -1,5 +1,9 @@
 package com.codeit.sprint.team3.backend.chat.application.port.in;
 
-public interface ChatHistoryUseCase {
+import com.codeit.sprint.team3.backend.chat.domain.ChatMessage;
 
+import java.util.List;
+
+public interface ChatHistoryUseCase {
+    List<ChatMessage> getRecentClubChatsForUser(Long userId);
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/chat/application/port/out/LoadRecentChatsPort.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/chat/application/port/out/LoadRecentChatsPort.java
@@ -1,0 +1,7 @@
+package com.codeit.sprint.team3.backend.chat.application.port.out;
+
+import com.codeit.sprint.team3.backend.chat.domain.ChatMessage;
+
+public interface LoadRecentChatsPort {
+    ChatMessage loadRecentChats(Long bookClubId);
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/chat/application/service/ChatHistoryService.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/chat/application/service/ChatHistoryService.java
@@ -1,0 +1,31 @@
+package com.codeit.sprint.team3.backend.chat.application.service;
+
+import com.codeit.sprint.team3.backend.bookclub.application.port.out.QueryBookClubPort;
+import com.codeit.sprint.team3.backend.bookclub.domain.BookClub;
+import com.codeit.sprint.team3.backend.bookclub.domain.OrderType;
+import com.codeit.sprint.team3.backend.chat.application.port.in.ChatHistoryUseCase;
+import com.codeit.sprint.team3.backend.chat.application.port.out.LoadRecentChatsPort;
+import com.codeit.sprint.team3.backend.chat.domain.ChatMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatHistoryService implements ChatHistoryUseCase {
+
+    private final QueryBookClubPort queryBookClubPort;
+    private final LoadRecentChatsPort loadRecentChatsPort;
+
+    @Override
+    public List<ChatMessage> getRecentClubChatsForUser(Long userId) {
+        return queryBookClubPort
+                .findUserJoinedBookClubs(userId, OrderType.DESC, Pageable.ofSize(100), false)
+                .stream()
+                .map(BookClub::getId)
+                .map(loadRecentChatsPort::loadRecentChats)
+                .toList();
+    }
+}


### PR DESCRIPTION
- /user/queue/chatHistory : 채팅 히스토리 개인화 구독 경로
- "/app/group-chat/recent" : 이 경로로 조회 요청 시 위 개인화 경로로 유저가 참여한 모든 모임의 가장 최신 채팅 1건 응답.