### PR TITLE
feat: 채팅방별 모든 히스토리 조회 기능 구현

### DIFF
--- a/src/main/java/com/codeit/sprint/team3/backend/chat/adapter/in/web/ChatController.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/chat/adapter/in/web/ChatController.java
@@ -1,6 +1,7 @@
 package com.codeit.sprint.team3.backend.chat.adapter.in.web;
 
 import com.codeit.sprint.team3.backend.auth.domain.model.User;
+import com.codeit.sprint.team3.backend.chat.adapter.in.web.response.HistoryResponses;
 import com.codeit.sprint.team3.backend.chat.application.port.in.ChatHistoryUseCase;
 import com.codeit.sprint.team3.backend.chat.application.port.in.SaveChatMessageUseCase;
 import com.codeit.sprint.team3.backend.chat.domain.ChatMessage;
@@ -31,13 +32,13 @@ public class ChatController {
     @MessageMapping("/group-chat/{chatRoomId}/sendMessage")
     public void sendMessage(
             @Header(name = "simpSessionAttributes") Map<String, Object> sessionAttributes,
-            @DestinationVariable String chatRoomId, //경로에서 추출
+            @DestinationVariable Long chatRoomId, //경로에서 추출
             @Payload ChatMessageReceived chatMessageReceived
     ) {
         User user = (User) sessionAttributes.get("user");
 
         ChatMessage chatMessage = new ChatMessage(
-                Long.parseLong(chatRoomId),
+                chatRoomId,
                 ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toLocalDateTime(),
                 user.getId(),
                 user.getNickname(),
@@ -53,12 +54,23 @@ public class ChatController {
 
     @MessageMapping("/group-chat/recent")
     @SendToUser("/queue/chatHistory")
-    public List<ChatMessage> getHistory(
+    public List<ChatMessage> getRecentChats(
             @Header(name = "simpSessionAttributes") Map<String, Object> sessionAttributes
     ) {
         User user = (User) sessionAttributes.get("user");
 
         return chatHistoryUseCase.getRecentClubChatsForUser(user.getId());
+    }
+
+    @MessageMapping("/group-chat/history/{chatRoomId}")
+    @SendToUser("/queue/chatHistory")
+    public HistoryResponses getAllChatsByBookClubId(
+            @Header(name = "simpSessionAttributes") Map<String, Object> sessionAttributes,
+            @DestinationVariable Long chatRoomId //경로에서 추출
+    ) {
+        User user = (User) sessionAttributes.get("user");
+
+        return HistoryResponses.from(chatHistoryUseCase.getAllClubChats(user.getId(), chatRoomId));
     }
 
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/chat/adapter/in/web/response/HistoryResponse.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/chat/adapter/in/web/response/HistoryResponse.java
@@ -1,0 +1,15 @@
+package com.codeit.sprint.team3.backend.chat.adapter.in.web.response;
+
+import com.codeit.sprint.team3.backend.chat.domain.ChatMessage;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record HistoryResponse(
+        LocalDate date,
+        List<ChatMessage> messages
+) {
+    public static HistoryResponse of(LocalDate date, List<ChatMessage> messages) {
+        return new HistoryResponse(date, messages);
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/chat/adapter/in/web/response/HistoryResponses.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/chat/adapter/in/web/response/HistoryResponses.java
@@ -1,0 +1,29 @@
+package com.codeit.sprint.team3.backend.chat.adapter.in.web.response;
+
+import com.codeit.sprint.team3.backend.chat.domain.ChatMessage;
+
+import java.time.LocalDate;
+import java.util.*;
+
+public record HistoryResponses(List<HistoryResponse> historyResponses){
+    public static HistoryResponses from(List<ChatMessage> messages) {
+        List<HistoryResponse> histories = new ArrayList<>();
+
+        TreeMap<LocalDate, List<ChatMessage>> messagesByDate = new TreeMap<>();
+
+        messages.forEach(m -> {
+            LocalDate date = m.getDate().toLocalDate();
+            if(!messagesByDate.containsKey(date)) {
+                messagesByDate.put(date, new ArrayList<>());
+            }
+            messagesByDate.get(date).add(m);
+        });
+
+        messagesByDate.forEach((date, lst) -> {
+            lst.sort(Comparator.comparing(ChatMessage::getDate));
+            histories.add(new HistoryResponse(date, lst));
+        });
+
+        return new HistoryResponses(histories);
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/chat/adapter/out/persistence/ChatMessageRepository.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/chat/adapter/out/persistence/ChatMessageRepository.java
@@ -2,6 +2,10 @@ package com.codeit.sprint.team3.backend.chat.adapter.out.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ChatMessageRepository extends JpaRepository<ChatMessageEntity, Long> {
     ChatMessageEntity findTopByBookClubIdOrderByDateDesc(Long bookClubId);
+
+    List<ChatMessageEntity> findByBookClubId(Long bookClubId);
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/chat/adapter/out/persistence/ChatPersistenceAdapter.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/chat/adapter/out/persistence/ChatPersistenceAdapter.java
@@ -1,6 +1,7 @@
 package com.codeit.sprint.team3.backend.chat.adapter.out.persistence;
 
-import com.codeit.sprint.team3.backend.chat.application.port.out.LoadRecentChatsPort;
+import com.codeit.sprint.team3.backend.bookclub.adapter.out.persistence.entity.BookClubEntity;
+import com.codeit.sprint.team3.backend.chat.application.port.out.LoadChatPort;
 import com.codeit.sprint.team3.backend.chat.application.port.out.SaveChatMessagePort;
 import com.codeit.sprint.team3.backend.chat.domain.ChatMessage;
 import lombok.RequiredArgsConstructor;
@@ -11,7 +12,7 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-public class ChatPersistenceAdapter implements SaveChatMessagePort, LoadRecentChatsPort {
+public class ChatPersistenceAdapter implements SaveChatMessagePort, LoadChatPort {
 
     private final ChatMessageRepository chatMessageRepository;
 
@@ -24,8 +25,14 @@ public class ChatPersistenceAdapter implements SaveChatMessagePort, LoadRecentCh
     }
 
     @Override
-    public ChatMessage loadRecentChats(Long bookClubId) {
-        System.out.println("Load recent chats - bookClubId: " + bookClubId);
+    @Transactional(readOnly = true)
+    public ChatMessage loadRecentChat(Long bookClubId) {
         return chatMessageRepository.findTopByBookClubIdOrderByDateDesc(bookClubId).toDomain();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ChatMessage> loadAllChat(Long bookClubId) {
+        return chatMessageRepository.findByBookClubId(bookClubId).stream().map(ChatMessageEntity::toDomain).toList();
     }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/chat/application/port/in/ChatHistoryUseCase.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/chat/application/port/in/ChatHistoryUseCase.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface ChatHistoryUseCase {
     List<ChatMessage> getRecentClubChatsForUser(Long userId);
+
+    List<ChatMessage> getAllClubChats(Long userId, Long bookClubId);
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/chat/application/port/out/LoadChatPort.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/chat/application/port/out/LoadChatPort.java
@@ -1,0 +1,10 @@
+package com.codeit.sprint.team3.backend.chat.application.port.out;
+
+import com.codeit.sprint.team3.backend.chat.domain.ChatMessage;
+
+import java.util.List;
+
+public interface LoadChatPort {
+    ChatMessage loadRecentChat(Long bookClubId);
+    List<ChatMessage> loadAllChat(Long bookClubId);
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/chat/application/port/out/LoadRecentChatsPort.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/chat/application/port/out/LoadRecentChatsPort.java
@@ -1,7 +1,0 @@
-package com.codeit.sprint.team3.backend.chat.application.port.out;
-
-import com.codeit.sprint.team3.backend.chat.domain.ChatMessage;
-
-public interface LoadRecentChatsPort {
-    ChatMessage loadRecentChats(Long bookClubId);
-}

--- a/src/main/java/com/codeit/sprint/team3/backend/chat/application/service/ChatHistoryService.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/chat/application/service/ChatHistoryService.java
@@ -4,8 +4,9 @@ import com.codeit.sprint.team3.backend.bookclub.application.port.out.QueryBookCl
 import com.codeit.sprint.team3.backend.bookclub.domain.BookClub;
 import com.codeit.sprint.team3.backend.bookclub.domain.OrderType;
 import com.codeit.sprint.team3.backend.chat.application.port.in.ChatHistoryUseCase;
-import com.codeit.sprint.team3.backend.chat.application.port.out.LoadRecentChatsPort;
+import com.codeit.sprint.team3.backend.chat.application.port.out.LoadChatPort;
 import com.codeit.sprint.team3.backend.chat.domain.ChatMessage;
+import com.codeit.sprint.team3.backend.chat.exception.UnauthorizedChatRoomAccessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -17,7 +18,7 @@ import java.util.List;
 public class ChatHistoryService implements ChatHistoryUseCase {
 
     private final QueryBookClubPort queryBookClubPort;
-    private final LoadRecentChatsPort loadRecentChatsPort;
+    private final LoadChatPort loadChatPort;
 
     @Override
     public List<ChatMessage> getRecentClubChatsForUser(Long userId) {
@@ -25,7 +26,22 @@ public class ChatHistoryService implements ChatHistoryUseCase {
                 .findUserJoinedBookClubs(userId, OrderType.DESC, Pageable.ofSize(100), false)
                 .stream()
                 .map(BookClub::getId)
-                .map(loadRecentChatsPort::loadRecentChats)
+                .map(loadChatPort::loadRecentChat)
                 .toList();
+    }
+
+    @Override
+    public List<ChatMessage> getAllClubChats(Long userId, Long bookClubId) {
+        boolean isJoined = queryBookClubPort
+                .findUserJoinedBookClubs(userId, OrderType.DESC, Pageable.ofSize(100), false)
+                .stream()
+                .map(BookClub::getId)
+                .anyMatch(id -> id.equals(bookClubId));
+
+        if(!isJoined) {
+            throw new UnauthorizedChatRoomAccessException("유저가 참여하지 않은 북클럽의 채팅 정보는 조회할 수 없습니다.");
+        }
+
+        return loadChatPort.loadAllChat(bookClubId);
     }
 }

--- a/src/main/java/com/codeit/sprint/team3/backend/chat/exception/UnauthorizedChatRoomAccessException.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/chat/exception/UnauthorizedChatRoomAccessException.java
@@ -1,0 +1,7 @@
+package com.codeit.sprint.team3.backend.chat.exception;
+
+public class UnauthorizedChatRoomAccessException extends RuntimeException{
+    public UnauthorizedChatRoomAccessException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/codeit/sprint/team3/backend/chat/exception/WebSocketExceptionHandler.java
+++ b/src/main/java/com/codeit/sprint/team3/backend/chat/exception/WebSocketExceptionHandler.java
@@ -1,0 +1,15 @@
+package com.codeit.sprint.team3.backend.chat.exception;
+
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+
+@ControllerAdvice(basePackages = "com.codeit.sprint.team3.backend.chat")
+public class WebSocketExceptionHandler {
+
+    @MessageExceptionHandler(UnauthorizedChatRoomAccessException.class)
+    @SendToUser("/queue/errors")
+    public String handleUnauthorizedAccess(UnauthorizedChatRoomAccessException ex) {
+        return ex.getMessage(); // 에러 메시지를 사용자에게 전송
+    }
+}


### PR DESCRIPTION
- /user/queue/chatHistory 구독
- /app/group-chat/history/{chatRoomId} 로 요청 시 위 구독 경로로 특정 채팅방의 모든 채팅 내역 응답
- 응답 객체는 HistoryResponses로 [{date, messages}, {date, messages}..] 형태로 구현.
- HistoryResponses는 날짜순 정렬 및 내부 메시지 리스트는 시간 순 정렬